### PR TITLE
Add BeforeAtRuleBlock/AfterAtRuleBlock properties for OutputFormat

### DIFF
--- a/lib/Sabberworm/CSS/CSSList/AtRuleBlockList.php
+++ b/lib/Sabberworm/CSS/CSSList/AtRuleBlockList.php
@@ -35,9 +35,11 @@ class AtRuleBlockList extends CSSBlockList implements AtRule {
 		if($sArgs) {
 			$sArgs = ' ' . $sArgs;
 		}
-		$sResult = "@{$this->sType}$sArgs{$oOutputFormat->spaceBeforeOpeningBrace()}{";
+		$sResult  = $oOutputFormat->sBeforeAtRuleBlock;
+		$sResult .= "@{$this->sType}$sArgs{$oOutputFormat->spaceBeforeOpeningBrace()}{";
 		$sResult .= parent::render($oOutputFormat);
 		$sResult .= '}';
+		$sResult .= $oOutputFormat->sAfterAtRuleBlock;
 		return $sResult;
 	}
 

--- a/lib/Sabberworm/CSS/OutputFormat.php
+++ b/lib/Sabberworm/CSS/OutputFormat.php
@@ -40,6 +40,10 @@ class OutputFormat {
 	public $sSpaceAfterBlocks = '';
 	public $sSpaceBetweenBlocks = "\n";
 
+	// Content injected in and around @-rule blocks.
+	public $sBeforeAtRuleBlock = '';
+	public $sAfterAtRuleBlock = '';
+
 	// This is what’s printed before and after the comma if a declaration block contains multiple selectors.
 	public $sSpaceBeforeSelectorSeparator = '';
 	public $sSpaceAfterSelectorSeparator = ' ';


### PR DESCRIPTION
This is needed for https://github.com/Automattic/amp-wp/pull/1423 in order to inject comments before and after `@-rules` so that they can be split apart and more easily identified for removal during tree shaking.